### PR TITLE
Feature/run choreography

### DIFF
--- a/.github/workflows/shieldx-client.yml
+++ b/.github/workflows/shieldx-client.yml
@@ -1,0 +1,43 @@
+name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+
+on:
+  push:
+    tags:
+      - "*" # Trigger on ANY tag push
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: poetry install
+
+      - name: Build wheel and sdist
+        run: poetry build
+
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Configure TestPyPI repository
+        run: poetry config repositories.testpypi https://test.pypi.org/legacy/
+
+      - name: Publish to TestPyPI
+        env:
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TESTPYPI_API_TOKEN }}
+        run: poetry publish -r testpypi --username __token__ --password $POETRY_PYPI_TOKEN_TESTPYPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a2"
+version = "0.0.1a4"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "shieldx-core (==0.0.1a10)",
+    "shieldx-core (==0.0.1a11)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.1.0"
+version = "0.0.1a0"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a4"
+version = "0.0.1a5"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}
@@ -12,7 +12,7 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "shieldx-core (==0.0.1a11)",
+    "shieldx-core (==0.0.1a12)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a5"
+version = "0.0.1a6"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}
@@ -12,7 +12,7 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "shieldx-core (==0.0.1a12)",
+    "shieldx-core (==0.0.1a13)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,10 @@ dependencies = [
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
     "bson (>=0.5.10,<0.6.0)",
-    "shieldx-core (==0.0.1a6)",
+    "shieldx-core (==0.0.1a9)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
+
 [[tool.poetry.source]]
 name = "test"
 url = "https://test.pypi.org/simple/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a0"
+version = "0.0.1a1"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}
@@ -12,7 +12,6 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "bson (>=0.5.10,<0.6.0)",
     "shieldx-core (==0.0.1a9)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a7"
+version = "0.0.1a8"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}
@@ -12,7 +12,7 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "shieldx-core (==0.0.1a14)",
+    "shieldx-core (==0.0.1a15)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a1"
+version = "0.0.1a2"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}
@@ -12,7 +12,7 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "shieldx-core (==0.0.1a9)",
+    "shieldx-core (==0.0.1a10)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shieldx-client"
-version = "0.0.1a6"
+version = "0.0.1a7"
 description = ""
 authors = [
     {name = "Ignacio Castillo",email = "ignacio.bcastillo@gmail.com"}
@@ -12,7 +12,7 @@ dependencies = [
     "httpx (>=0.28.1,<0.29.0)",
     "pydantic (>=2.11.4,<3.0.0)",
     "option (>=2.1.0,<3.0.0)",
-    "shieldx-core (==0.0.1a13)",
+    "shieldx-core (==0.0.1a14)",
     "PyYAML (>=6.0.2,<7.0.0)",
 ]
 

--- a/shieldx_client/choreography/schema.py
+++ b/shieldx_client/choreography/schema.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Any, Optional, Union
 from pydantic import BaseModel, Field, model_validator
 """Pydantic models for the choreography YAML.
 
@@ -11,7 +11,6 @@ Models:
 - ChoreographySpec: YAML root with basic validation.
 """
 
-ParamType = Literal["string", "int", "float", "bool", "json"]  # 'json' lo mapeamos si quieres permitirlo
 
 """Allowed parameter types for a Rule.
 
@@ -19,29 +18,84 @@ Note:
     If your backend does not support native `json`, map it to `string` in the interpreter.
 """
 
-class ParameterSpec(BaseModel):
-    """Rule parameter specification.
-
-    Attributes:
-        type: Parameter type (see `ParamType`).
-        description: Optional description.
-        required: Whether the parameter is required (default: True).
-        default: Optional default value.
+class RefSpec(BaseModel):
     """
-    type: ParamType
+    A parameter value that can either be:
+        - a literal `value`, OR
+        - an external reference via `ref` or `$ref` (string-validated, existence not required here).
+    Optional metadata fields are accepted for DX (type/name/description).
+    """
+    ref: Optional[str] = None
+    ref_dollar: Optional[str] = Field(default=None, alias="$ref")
+
+    value: Optional[Any] = None
+
+    type: Optional[str] = None
+    name: Optional[str] = None
     description: Optional[str] = None
-    required: bool = True
-    default: Optional[object] = None
 
-class RuleRef(BaseModel):
+    @model_validator(mode="after")
+    def _require_ref_or_value(self) -> "RefSpec":
+        effective_ref = self.ref or self.ref_dollar
+        if effective_ref is None and self.value is None:
+            raise ValueError("RefSpec requires either 'ref'/'$ref' or 'value'.")
+        if effective_ref is not None and not isinstance(effective_ref, str):
+            raise ValueError("'ref'/'$ref' must be a string.")
+        return self
+
+ParamValue = Union[RefSpec, Any]  # Each parameter can be a RefSpec or a plain literal
+
+
+# ----------------
+# Parameters (init/call)
+# ----------------
+
+class ParametersSpec(BaseModel):
+    """
+    Split parameters:
+        - init: kwargs passed to the class constructor (__init__)
+        - call: kwargs passed to the selected method (default: 'run')
+    At least one of {init, call} must be present.
+    """
+    init: Optional[Dict[str, ParamValue]] = None
+    call: Optional[Dict[str, ParamValue]] = None
+
+    @model_validator(mode="after")
+    def _at_least_one_block(self) -> "ParametersSpec":
+        if not (self.init or self.call):
+            raise ValueError("Provide at least one of 'parameters.init' or 'parameters.call'.")
+        return self
+
+class TargetSpec(BaseModel):
+    """
+    Identify the invocation target:
+        - alias: "artifact_or_class.method"
+            (Runner should resolve class + method; method default 'run' if not present in alias)
+        - OR a persisted object:
+            bucket_id + key (+ method, default 'run')
+    """
+    alias: Optional[str] = None
+    bucket_id: Optional[str] = None
+    key: Optional[str] = None
+    method: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _require_alias_or_bucket_key(self) -> "TargetSpec":
+        has_alias = bool(self.alias)
+        has_bucket_key = bool(self.bucket_id and self.key)
+        if not has_alias and not has_bucket_key:
+            raise ValueError("TargetSpec requires 'alias' OR ('bucket_id' and 'key').")
+        return self
+
+
+class RuleSpec(BaseModel):
     """Reference to a Rule: target + parameters.
-
     Attributes:
         target: Target function/action identifier.
         parameters: Mapping of parameter name to `ParameterSpec`.
     """
-    target: str
-    parameters: Dict[str, ParameterSpec] = Field(default_factory=dict)
+    target: TargetSpec
+    parameters: ParametersSpec
 
 class TriggerSpec(BaseModel):
     """Trigger definition.
@@ -52,7 +106,8 @@ class TriggerSpec(BaseModel):
         event_types: Optional list of Event Type names to bind; if empty, `name` is used.
     """
     name: str
-    rule: RuleRef
+    depends_on: Optional[str] = None
+    rule: RuleSpec
     # M:N con EventTypes (si no lo pones, se usa name como event_type)
     event_types: List[str] = Field(default_factory=list)
 

--- a/shieldx_client/client.py
+++ b/shieldx_client/client.py
@@ -723,7 +723,7 @@ class ShieldXClient:
         except Exception as e:
             return Err(e)
 
-    async def create_trigger_dict(self, name: str) -> Result[dict, Exception]:
+    async def create_trigger_dict(self,payload: dict) -> Result[dict, Exception]:
         """Create a Trigger and return a small dict.
 
         Args:
@@ -733,11 +733,12 @@ class ShieldXClient:
             Dict `{"id": str, "name": str}`.
         """
         try:
-            res = await self.create_trigger(DTOS.TriggerCreateDTO(name=name))
+            dto = DTOS.TriggerCreateDTO(**payload)
+            res = await self.create_trigger(dto)
             if res.is_err:
                 return Err(res.unwrap_err())
             msg = res.unwrap()
-            return Ok({"id": msg.id, "name": name})
+            return Ok({"id": msg.id, "name": dto.name})
         except Exception as e:
             return Err(e)
 

--- a/shieldx_client/client.py
+++ b/shieldx_client/client.py
@@ -48,6 +48,27 @@ class ShieldXClient:
         if token:
             self.headers["Authorization"] = f"Bearer {token}"
 
+    async def run_choreography(self,enriched_graph: DTOS.EnrichedGraphSpecDTO,headers: Dict[str, str] = {}) -> Result[dict, Exception]:
+        """
+        Envía un grafo enriquecido (con puertos y host de endpoints) a ShieldX para su ejecución.
+
+        Args:
+            enriched_graph: Objeto `EnrichedGraphSpecDTO` con los vértices y aristas
+                            del grafo enriquecido, incluyendo información de despliegue.
+            headers: Encabezados HTTP adicionales (opcional).
+
+        Returns:
+            Result[dict, Exception]: JSON de respuesta devuelto por ShieldX o un error.
+        """
+        try:
+            path = "/choreography/run"
+            payload = enriched_graph.model_dump(exclude_none=True)
+
+    
+            res = await self._post(path=path,payload=payload,model=None, operation="RUN_CHOREOGRAPHY",headers=headers)
+            return res
+        except Exception as e:
+            return Err(e)
 
     def interpret(self, choreography_path_or_text: str, *, as_text: bool = False) -> Result[Dict[str, Any], Exception]:
         """Interpret a choreography YAML and index entities (blocking).

--- a/tests/test_choreography_interpreter.py
+++ b/tests/test_choreography_interpreter.py
@@ -9,7 +9,7 @@ async def test_interpret_choreography_real_yaml():
     Prueba el intérprete usando un YAML real desde el disco.
     """
     # Ruta al YAML real
-    yaml_path = Path(__file__).parent.parent / "triggers.yml"
+    yaml_path = Path(__file__).parent.parent / "trigger2.yml"
     assert yaml_path.exists(), f"No se encontró el archivo {yaml_path}"
 
     client = ShieldXClient(base_url="http://localhost:20000/api/v1")

--- a/tests/test_rule_client.py
+++ b/tests/test_rule_client.py
@@ -1,0 +1,202 @@
+from uuid import uuid4
+import pytest
+from shieldx_client.client import ShieldXClient
+from shieldx_core.dtos import (TriggerCreateDTO, MessageWithIDDTO, EventTypeCreateDTO, EventCreateDTO, 
+                                RuleCreateDTO, RuleUpdateDTO, TriggerUpdateDTO, EventUpdateDTO)
+
+BASE_URL = "http://localhost:20000/api/v1"
+
+client = ShieldXClient(base_url=BASE_URL)
+
+@pytest.mark.skip("")
+@pytest.mark.asyncio
+async def test_create_rule():
+    rule = RuleCreateDTO(
+                        target={
+                            "alias": "bellmanford_v1test1.run"
+                        },
+                        parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param": {"value": "A"},
+                            },
+                            "call":{  
+                                "source": {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+    )
+    result = await client.create_rule(rule)
+    print(result)
+    assert result.is_ok
+
+@pytest.mark.skip("")
+@pytest.mark.asyncio
+async def test_get_rule_by_id():
+    rule = RuleCreateDTO(
+                        target={
+                            "alias": "bellmanford_v1test1.run"
+                        },
+                        parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param": {"value": "A"},
+                            },
+                            "call":{  
+                                "source": {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+    )
+    created = await client.create_rule(rule)
+    assert created.is_ok
+    rule_id = created.unwrap()
+
+    result = await client.get_rule_by_id(rule_id.id)
+    assert result.is_ok
+    fetched = result.unwrap()
+    assert fetched.rule_id == rule_id.id
+    assert fetched.target.alias == "bellmanford_v1test1.run"
+
+@pytest.mark.skip("")
+@pytest.mark.asyncio
+async def test_list_rules():
+    result = await client.list_rules()
+    assert result.is_ok
+    rules = result.unwrap()
+    assert isinstance(rules, list)
+    
+@pytest.mark.skip("")
+@pytest.mark.asyncio
+async def test_update_rule():
+    rule = RuleCreateDTO(
+                        target={
+                            "alias": "bellmanford_v1test1original.run"
+                        },
+                        parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param": {"value": "A"},
+                            },
+                            "call":{  
+                                "source": {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+    )
+    created = await client.create_rule(rule)
+    print(created)
+    assert created.is_ok
+    rule_id = created.unwrap()
+    rule_id = rule_id.id
+    updated_rule = RuleCreateDTO(
+                        target={
+                            "alias": "bellmanford_v1test1Update.run"
+                        },
+                        parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param": {"value": "A"},
+                            },
+                            "call":{  
+                                "source": {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+    )
+    update_result = await client.update_rule(rule_id, updated_rule)
+    assert update_result.is_ok
+    msg = update_result.unwrap()
+    assert msg.message == "Rule updated"
+    
+@pytest.mark.skip("")
+@pytest.mark.asyncio
+async def test_delete_rule():
+    rule = RuleCreateDTO(
+                        target={
+                            "alias": "bellmanford_v1test1Update.run"
+                        },
+                        parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param": {"value": "A"},
+                            },
+                            "call":{  
+                                "source": {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+    )
+    created = await client.create_rule(rule)
+    assert created.is_ok
+    rule_id = created.unwrap()
+
+    result = await client.delete_rule(rule_id.id)
+    assert result.is_ok
+    assert result.unwrap() is True
+
+
+@pytest.mark.asyncio
+async def test_create_trigger():
+    trigger = TriggerCreateDTO(
+        name=f"test_trigger_create-{uuid4()}",
+        depends_on="BellmanFordtest"
+    )
+    result = await client.create_trigger(trigger)
+    print(result)
+    assert result.is_ok

--- a/tests/test_rule_client.py
+++ b/tests/test_rule_client.py
@@ -8,7 +8,7 @@ BASE_URL = "http://localhost:20000/api/v1"
 
 client = ShieldXClient(base_url=BASE_URL)
 
-@pytest.mark.skip("")
+#@pytest.mark.skip("")
 @pytest.mark.asyncio
 async def test_create_rule():
     rule = RuleCreateDTO(
@@ -41,7 +41,7 @@ async def test_create_rule():
     print(result)
     assert result.is_ok
 
-@pytest.mark.skip("")
+#@pytest.mark.skip("")
 @pytest.mark.asyncio
 async def test_get_rule_by_id():
     rule = RuleCreateDTO(
@@ -80,7 +80,7 @@ async def test_get_rule_by_id():
     assert fetched.rule_id == rule_id.id
     assert fetched.target.alias == "bellmanford_v1test1.run"
 
-@pytest.mark.skip("")
+#@pytest.mark.skip("")
 @pytest.mark.asyncio
 async def test_list_rules():
     result = await client.list_rules()
@@ -88,7 +88,7 @@ async def test_list_rules():
     rules = result.unwrap()
     assert isinstance(rules, list)
     
-@pytest.mark.skip("")
+#@pytest.mark.skip("")
 @pytest.mark.asyncio
 async def test_update_rule():
     rule = RuleCreateDTO(
@@ -153,7 +153,7 @@ async def test_update_rule():
     msg = update_result.unwrap()
     assert msg.message == "Rule updated"
     
-@pytest.mark.skip("")
+#@pytest.mark.skip("")
 @pytest.mark.asyncio
 async def test_delete_rule():
     rule = RuleCreateDTO(

--- a/tests/test_shieldx_client.py
+++ b/tests/test_shieldx_client.py
@@ -189,12 +189,31 @@ async def test_delete_event():
 @pytest.mark.asyncio
 async def test_create_rule():
     rule = RuleCreateDTO(
-        target="mictlanx.get",
-        parameters={
-            "bucket_id": {"type": "string", "description": "ID del bucket"},
-            "key": {"type": "string", "description": "Llave"},
-            "sink_path": {"type": "string", "description": "Ruta destino"}
-        }
+        target={
+                            "alias": "bellmanford_v1test1.run"
+                        },
+            parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param":  {"value": "A"},
+                            },
+                            "call":{  
+                                "source":  {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+        
     )
     result = await client.create_rule(rule)
     print(result)
@@ -204,12 +223,31 @@ async def test_create_rule():
 @pytest.mark.asyncio
 async def test_get_rule_by_id():
     rule = RuleCreateDTO(
-        target="mictlanx.get",
-        parameters={
-            "bucket_id": {"type": "string", "description": "ID del bucket"},
-            "key": {"type": "string", "description": "Llave"},
-            "sink_path": {"type": "string", "description": "Ruta destino"}
-        }
+        target={
+                            "alias": "bellmanford_v1test2.run"
+                        },
+            parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param":  {"value": "A"},
+                            },
+                            "call":{  
+                                "source":  {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+        
     )
     created = await client.create_rule(rule)
     assert created.is_ok
@@ -219,7 +257,7 @@ async def test_get_rule_by_id():
     assert result.is_ok
     fetched = result.unwrap()
     assert fetched.rule_id == rule_id.id
-    assert fetched.target == "mictlanx.get"
+    assert fetched.target.alias == "bellmanford_v1test2.run"
 
 #@pytest.mark.skip("")
 @pytest.mark.asyncio
@@ -233,24 +271,50 @@ async def test_list_rules():
 @pytest.mark.asyncio
 async def test_update_rule():
     rule = RuleCreateDTO(
-        target="original_function",
-        parameters={
-            "bucket_id": {"type": "string", "description": "ID del bucket"},
-            "key": {"type": "string", "description": "Llave"},
-            "sink_path": {"type": "string", "description": "Ruta destino"}
-        }
-    )
+        target={
+                            "alias": "bellmanford_v1test3.run"
+                        },
+            parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param":  {"value": "A"},
+                            },
+                            "call":{  
+                                "source":  {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+        )
     created = await client.create_rule(rule)
     print(created)
     assert created.is_ok
     rule_id = created.unwrap()
     rule_id = rule_id.id
     updated_rule = RuleUpdateDTO(
-        target="updated_function",
+        target={
+                            "alias": "bellmanford_v1test3Update.run"
+                        },
         parameters={
-            "bucket_id": {"type": "string", "description": "ID del bucket"},
-            "key": {"type": "string", "description": "Llave"},
-            "sink_path": {"type": "string", "description": "Ruta destino"}
+            "init":{  
+                                "graph":{
+                                        "type": "DiGraphUpdate",
+                                        "name": "graphUpdate",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param":  {"value": "A"},
+                            },
         }
     )
     update_result = await client.update_rule(rule_id, updated_rule)
@@ -262,11 +326,31 @@ async def test_update_rule():
 @pytest.mark.asyncio
 async def test_delete_rule():
     rule = RuleCreateDTO(
-        target="to_be_deleted",
-        parameters={
-            "x": {"type": "bool", "description": "to be removed"}
-        }
-    )
+        target={
+                            "alias": "bellmanford_v1test4.run"
+                        },
+            parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param":  {"value": "A"},
+                            },
+                            "call":{  
+                                "source":  {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+        )
     created = await client.create_rule(rule)
     assert created.is_ok
     rule_id = created.unwrap()
@@ -281,14 +365,7 @@ async def test_delete_rule():
 async def test_create_trigger():
     trigger = TriggerCreateDTO(
         name=f"test_trigger_create-{uuid4()}",
-        rule=RuleCreateDTO(
-            target="mictlanx.get",
-            parameters={
-                "bucket_id": {"type": "string", "description": "ID del bucket"},
-                "key": {"type": "string", "description": "Llave"},
-                "sink_path": {"type": "string", "description": "Ruta destino"}
-            }
-        )
+        depends_on="bellmanford_v1test4"
     )
     result = await client.create_trigger(trigger)
     print(result)
@@ -300,14 +377,7 @@ async def test_get_trigger_by_name():
     name = f"test_trigger_get-{uuid4()}"
     trigger = TriggerCreateDTO(
         name=name,
-        rule=RuleCreateDTO(
-            target="mictlanx.get",
-            parameters={
-                "bucket_id": {"type": "string", "description": "ID del bucket"},
-                "key": {"type": "string", "description": "Llave"},
-                "sink_path": {"type": "string", "description": "Ruta destino"}
-            }
-        )
+        depends_on="bellmanford_v1test4"
     )
     created = await client.create_trigger(trigger)
     assert created.is_ok
@@ -332,28 +402,14 @@ async def test_update_trigger():
     name = f"test_trigger_update-{uuid4()}"
     trigger = TriggerCreateDTO(
         name=name,
-        rule=RuleCreateDTO(
-            target="original_function",
-            parameters={
-                "bucket_id": {"type": "string", "description": "ID del bucket"},
-                "key": {"type": "string", "description": "Llave"},
-                "sink_path": {"type": "string", "description": "Ruta destino"}
-            }
-        )
+        depends_on="bellmanford_v1test4"
     )
     created = await client.create_trigger(trigger)
     assert created.is_ok
 
     updated_trigger = TriggerUpdateDTO(
         name=name,
-        rule=RuleUpdateDTO(
-            target="updated_function",
-            parameters={
-                "bucket_id": {"type": "string", "description": "ID del bucket"},
-                "key": {"type": "string", "description": "Llave"},
-                "sink_path": {"type": "string", "description": "Ruta destino"}
-            }
-        )
+        depends_on="bellmanford_v1test4Update"
     )
     update_result = await client.update_trigger(name, updated_trigger)
     assert update_result.is_ok
@@ -366,12 +422,7 @@ async def test_delete_trigger():
     name = "test_trigger_delete"
     trigger = TriggerCreateDTO(
         name=name,
-        rule=RuleCreateDTO(
-            target="to_be_deleted",
-            parameters={
-                "x": {"type": "bool", "description": "to be removed"}
-            }
-        )
+        depends_on="bellmanford_v1test4"
     )
     created = await client.create_trigger(trigger)
     assert created.is_ok
@@ -421,13 +472,31 @@ async def test_link_trigger_to_event_type():
 @pytest.mark.asyncio
 async def test_link_rule_to_trigger():
     rule = RuleCreateDTO(
-        target="mictlanx.get",
-        parameters={
-            "bucket_id": {"type": "string", "description": "ID del bucket"},
-            "key": {"type": "string", "description": "Llave"},
-            "sink_path": {"type": "string", "description": "Ruta destino"}
-        }
-    )
+        target={
+                            "alias": "bellmanford_v1test3.run"
+                        },
+            parameters={
+                            "init":{  
+                                "graph":{
+                                        "type": "DiGraph",
+                                        "name": "graph",
+                                        "description": "Grafo dirigido almacenado en MictlanX",
+                                        "ref": "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+                                },
+                                "other_init_param":  {"value": "A"},
+                            },
+                            "call":{  
+                                "source":  {"value": "A"},
+                                "target":{
+                                    "$ref": "mictlanx://params_bucket@target_label/0/?content_type=text/plain",
+                                    "type": "str",
+                                    "name": "target",
+                                    "description": "Nodo destino",
+                                    "value": "Z"
+                                },
+                            }
+                        }
+        )
     trigger_id = f"trigger_id-{uuid4()}"
 
     rule_result = await client.create_rule(rule)

--- a/trigger2.yml
+++ b/trigger2.yml
@@ -1,0 +1,38 @@
+triggers:
+  - name: "BellmanFordtest"
+    rule:
+      target:
+        alias: "bellmanford_v1.run"   # → Clase BellmanFordAlgorithm + método run
+        # method por defecto es "run", pero si el alias ya incluye ".run", está bien.
+      parameters:
+        init:                         # → kwargs para __init__(**init)
+          graph:                      # Parametro admitiendo RefSpec
+            type: "DiGraph"
+            name: "graph"
+            description: "Grafo dirigido almacenado en MictlanX"
+            ref: "mictlanx://graphs_bucket@graph_k1/0/?content_type=application/octet-stream"
+          other_init_param: "A"
+        call:                         # → kwargs para obj.run(**call)
+          source: "A"
+          target:
+            # Ejemplo usando $ref en lugar de ref (alias soportado por el modelo)
+            $ref: "mictlanx://params_bucket@target_label/0/?content_type=text/plain"
+            type: "str"
+            name: "target"
+            description: "Nodo destino"
+            value: "Z"
+
+  - name: "PlotGraph"
+    depends_on: "BellmanFordtest"
+    rule:
+      target:
+        alias: "bellmanford_v1.plot"
+        # method: "plot"  # No necesario si el alias ya lo especifica
+      parameters:
+        call:
+          algorithm_name: "BellmanFord"
+          save_plot: true
+          # Dónde guardar la imagen (literales):
+          sink_bucket_id: "plots_bucket"
+          sink_key: "bf_run_001.png"
+          # Metadatos arbitrarios (dict literal)


### PR DESCRIPTION
### *Descripción:*
Este PR agrega el método run_choreography() al cliente de ShieldX, permitiendo enviar un grafo enriquecido (EnrichedGraphSpecDTO) al backend de ShieldX para su ejecución.
El método serializa el modelo, realiza la petición POST /choreography/run.
### 🔧 Cambios principales

- Nueva función run_choreography() en ShieldXClient.
- Soporte para envío de EnrichedGraphSpecDTO con información de despliegue (host, req_res_port, pubsub_port).
